### PR TITLE
Fixed parsing of ArrayList during request bulding

### DIFF
--- a/src/main/java/com/signaturit/api/java_sdk/RequestHelper.java
+++ b/src/main/java/com/signaturit/api/java_sdk/RequestHelper.java
@@ -88,10 +88,8 @@ class RequestHelper {
 			}
 		} else if (recipients instanceof ArrayList<?>) {
 			int i = 0;
-			for ( HashMap<String, Object> recipient: (ArrayList<HashMap<String, Object>>) recipients ) {
-				for (Entry<String, Object>  entry : recipient.entrySet()) {
-					parseParameters(bodyBuilder, entry.getValue(), key+"["+i+"]["+entry.getKey()+"]");
-				}
+			for (Object recipient: (ArrayList<Object>) recipients) {
+				parseParameters(bodyBuilder, recipient, key+"["+i+"]");
 				++i;
 			}
 		} else if (recipients instanceof HashMap) {


### PR DESCRIPTION
There was some extra work done badly when the object being processed during request build time was an ArrayList. The implementation expected the contents of the array to be a Map and then iterated over it. Instead, now every element of the List is processed and the 'parseParameters' function is called recursively with the List element as input, this way we let the recursive function to go down iterating over the collections until it gets to the primary elements.

This way there is no more need to define Maps with numeric keys as:
map.put("0", Object)
Instead, every collection that must be in order has to be build using Lists like:
ArrayList.add(widget1); ArrayList.add(widget2);